### PR TITLE
fix: synlink.sh unlink.sh update

### DIFF
--- a/symlink.sh
+++ b/symlink.sh
@@ -4,25 +4,30 @@
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
-ln -snv $SCRIPT_DIR/bin ~/.bin
-ln -snv $SCRIPT_DIR/config ~/.config
+if [ -d $HOME/.config ]; then
+  echo "move $HOME/.config directory"
+  mv $HOME/.config ${SCRIPT_DIR}/.config_tmp
+fi
 
-ln -snv $SCRIPT_DIR/bashrc ~/.bashrc
-ln -snv $SCRIPT_DIR/bash_profile ~/.bash_profile
+ln -snv ${SCRIPT_DIR}/bin $HOME/.bin
+ln -snv ${SCRIPT_DIR}/config $HOME/.config
 
-ln -snv $SCRIPT_DIR/zshrc ~/.zshrc
-ln -snv $SCRIPT_DIR/zplug.zsh ~/.zplug.zsh
+ln -snv ${SCRIPT_DIR}/bashrc $HOME/.bashrc
+ln -snv ${SCRIPT_DIR}/bash_profile $HOME/.bash_profile
 
-ln -snv $SCRIPT_DIR/vim ~/.vim
-ln -snv $SCRIPT_DIR/vimrc ~/.vimrc
+ln -snv ${SCRIPT_DIR}/zshrc $HOME/.zshrc
+ln -snv ${SCRIPT_DIR}/zplug.zsh $HOME/.zplug.zsh
 
-ln -snv $SCRIPT_DIR/tigrc ~/.tigrc
+ln -snv ${SCRIPT_DIR}/vim $HOME/.vim
+ln -snv ${SCRIPT_DIR}/vimrc $HOME/.vimrc
 
-ln -snv $SCRIPT_DIR/gitconfig ~/.gitconfig
-ln -snv $SCRIPT_DIR/gitignore ~/.gitignore
+ln -snv ${SCRIPT_DIR}/tigrc $HOME/.tigrc
 
-ln -snv $SCRIPT_DIR/tmux.conf ~/.tmux.conf
+ln -snv ${SCRIPT_DIR}/gitconfig $HOME/.gitconfig
+ln -snv ${SCRIPT_DIR}/gitignore $HOME/.gitignore
 
-ln -snv $SCRIPT_DIR/xinitrc ~/.xinitrc
+ln -snv ${SCRIPT_DIR}/tmux.conf $HOME/.tmux.conf
 
-ln -snv $SCRIPT_DIR/npmrc ~/.npmrc
+ln -snv ${SCRIPT_DIR}/xinitrc $HOME/.xinitrc
+
+ln -snv ${SCRIPT_DIR}/npmrc $HOME/.npmrc

--- a/unlink.sh
+++ b/unlink.sh
@@ -4,25 +4,25 @@
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
-unlink ~/.bin
-unlink ~/.config
+unlink $HOME/.bin
+unlink $HOME/.config
 
-unlink ~/.bashrc
-unlink ~/.bash_profile
+unlink $HOME/.bashrc
+unlink $HOME/.bash_profile
 
-unlink ~/.zshrc
-unlink ~/.zplug.zsh
+unlink $HOME/.zshrc
+unlink $HOME/.zplug.zsh
 
-unlink ~/.vim
-unlink ~/.vimrc
+unlink $HOME/.vim
+unlink $HOME/.vimrc
 
-unlink ~/.tigrc
+unlink $HOME/.tigrc
 
-unlink ~/.gitconfig
-unlink ~/.gitignore
+unlink $HOME/.gitconfig
+unlink $HOME/.gitignore
 
-unlink ~/.tmux.conf
+unlink $HOME/.tmux.conf
 
-unlink ~/.xinitrc
+unlink $HOME/.xinitrc
 
-unlink ~/.npmrc
+unlink $HOME/.npmrc


### PR DESCRIPTION
symlink.sh実行時に```$HOME/.config```が存在する場合の処理を追加
既存の.configは一時的に移動させる